### PR TITLE
Only googleBOT plus readability

### DIFF
--- a/is_googlebot.php
+++ b/is_googlebot.php
@@ -1,10 +1,12 @@
-function is_googlebot($ip, $check_user_agent = true) {
-    if (!$check_user_agent || strpos($_SERVER['HTTP_USER_AGENT'], 'Google') !== false) {
-        $host = gethostbyaddr($ip);
-        if (substr($host, -14) == '.googlebot.com') {
-            $host_ips = gethostbynamel($host);
-            foreach ($host_ips as $host_ip) {
-                if ($host_ip == $ip) {
+<?php
+
+function is_googlebot( $ip, $check_user_agent = true ) {
+    if ( ! $check_user_agent || false !== strpos( $_SERVER['HTTP_USER_AGENT'], 'Googlebot' ) ) {
+        $host = gethostbyaddr( $ip );
+        if ( substr( $host, -14 ) === '.googlebot.com' ) {
+            $host_ips = gethostbynamel( $host );
+            foreach ( $host_ips as $host_ip ) {
+                if ( $host_ip === $ip ) {
                     return true;
                 }
             }


### PR DESCRIPTION
Examples for _google_ but not _gooblebot_:
`AppEngine-Google; (+http://code.google.com/appengine; appid: s~nodeprox)`
`Feedly/1.0 (+http://www.feedly.com/fetcher.html; like FeedFetcher-Google`
